### PR TITLE
Method getSimilarity(string1, string2) in  GreedyStringTiling,

### DIFF
--- a/dkpro-similarity-algorithms-lexical-asl/src/main/java/org/dkpro/similarity/algorithms/lexical/string/GreedyStringTiling.java
+++ b/dkpro-similarity-algorithms-lexical-asl/src/main/java/org/dkpro/similarity/algorithms/lexical/string/GreedyStringTiling.java
@@ -71,6 +71,9 @@ public class GreedyStringTiling
 		MarkedString s1 = new MarkedString(string1);
 		MarkedString s2 = new MarkedString(string2);
 		
+		if (s1.length() == 0) {
+      			return 0;
+    		}
 		TileCollection finalTiles = new TileCollection(s1, s2);
 		
 		int maxmatch = Integer.MAX_VALUE;

--- a/dkpro-similarity-algorithms-lexical-asl/src/main/java/org/dkpro/similarity/algorithms/lexical/string/LongestCommonSubsequenceComparator.java
+++ b/dkpro-similarity-algorithms-lexical-asl/src/main/java/org/dkpro/similarity/algorithms/lexical/string/LongestCommonSubsequenceComparator.java
@@ -45,6 +45,9 @@ public class LongestCommonSubsequenceComparator
 	public double getSimilarity(String string1, String string2)
 		throws SimilarityException
 	{
+		if (string1.trim().isEmpty()) {
+      			return 0;
+    		}
 		String lcs = getLCS(string1, string2);
 		
 		// Normalize

--- a/dkpro-similarity-algorithms-lexical-asl/src/main/java/org/dkpro/similarity/algorithms/lexical/string/LongestCommonSubsequenceNormComparator.java
+++ b/dkpro-similarity-algorithms-lexical-asl/src/main/java/org/dkpro/similarity/algorithms/lexical/string/LongestCommonSubsequenceNormComparator.java
@@ -35,6 +35,9 @@ public class LongestCommonSubsequenceNormComparator
 	public double getSimilarity(String string1, String string2)
 		throws SimilarityException
 	{
+		if (string1.trim().isEmpty()) {
+      			return 0;
+    		}
 		String lcs = getLCS(string1.toLowerCase(), string2.toLowerCase());
 		
 		return (double) lcs.length() / string1.length();

--- a/dkpro-similarity-algorithms-lexical-asl/src/main/java/org/dkpro/similarity/algorithms/lexical/string/LongestCommonSubstringComparator.java
+++ b/dkpro-similarity-algorithms-lexical-asl/src/main/java/org/dkpro/similarity/algorithms/lexical/string/LongestCommonSubstringComparator.java
@@ -48,6 +48,9 @@ public class LongestCommonSubstringComparator
 	public double getSimilarity(String string1, String string2)
 		throws SimilarityException
 	{
+		if (string1.trim().isEmpty()) {
+     			return 0;
+   		}
 		String lcs = getLCS(string1, string2);
 		
 		// Normalize


### PR DESCRIPTION
Method getSimilarity(string1, string2) in 
- GreedyStringTiling
- LongestCommonSubsequenceComparator
- LongestCommonSubsequenceNormComparator, and
- LongestCommonSubstringComparator 

results in NaN if string1 is empty (note that in cases where string2 is the empty one, the result is 0). I added an if to the methods in the corresponding classes: if string1 is empty, return 0.