### PR TITLE
#69 - Use WordNet via Maven dependency

### DIFF
--- a/dkpro-similarity-algorithms-lsr-asl/pom.xml
+++ b/dkpro-similarity-algorithms-lsr-asl/pom.xml
@@ -86,6 +86,17 @@
       <artifactId>de.tudarmstadt.ukp.dkpro.lexsemresource.wordnet-asl</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>net.sf.extjwnl</groupId>
+      <artifactId>extjwnl-data-wn30</artifactId>
+      <version>1.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>
@@ -99,6 +110,8 @@
               <usedDependency>de.tudarmstadt.ukp.dkpro.lexsemresource:de.tudarmstadt.ukp.dkpro.lexsemresource.wikipedia-asl</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.dkpro.lexsemresource:de.tudarmstadt.ukp.dkpro.lexsemresource.wiktionary-asl</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.dkpro.lexsemresource:de.tudarmstadt.ukp.dkpro.lexsemresource.wordnet-asl</usedDependency>
+              <!-- Data dependencies are not detected by byte-code analysis -->
+              <usedDependency>net.sf.extjwnl:extjwnl-data-wn30</usedDependency>
             </usedDependencies>
           </configuration>
         </plugin>

--- a/dkpro-similarity-algorithms-lsr-asl/src/test/java/org/dkpro/similarity/algorithms/lsr/path/PathLengthComparatorTest.java
+++ b/dkpro-similarity-algorithms-lsr-asl/src/test/java/org/dkpro/similarity/algorithms/lsr/path/PathLengthComparatorTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.dkpro.similarity.algorithms.lsr.LexSemResourceComparator;
 import org.dkpro.similarity.algorithms.lsr.path.PathLengthComparator;
+import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -32,32 +33,37 @@ import org.junit.Test;
 
 import de.tudarmstadt.ukp.dkpro.lexsemresource.Entity;
 import de.tudarmstadt.ukp.dkpro.lexsemresource.Entity.PoS;
+import de.tudarmstadt.ukp.dkpro.lexsemresource.LSRFramework;
 import de.tudarmstadt.ukp.dkpro.lexsemresource.LexicalSemanticResource;
 import de.tudarmstadt.ukp.dkpro.lexsemresource.core.ResourceFactory;
-import de.tudarmstadt.ukp.dkpro.lexsemresource.exception.ResourceLoaderException;
 
 public class PathLengthComparatorTest {
 
     private static final double epsilon = 0.0001;
 
-    private static LexicalSemanticResource wordnet;
-    private static LexicalSemanticResource germanet;
-    private static LexicalSemanticResource wikipedia;
-    private static LexicalSemanticResource wiktionary;
-
+    private static String oldWorkspace;
+    
     @BeforeClass
-    public static void initialize() throws ResourceLoaderException  {
-        wordnet    = ResourceFactory.getInstance().get("wordnet3", "en");
-//        germanet   = ResourceFactory.getInstance().get("germanet7", "de");
-        wikipedia  = ResourceFactory.getInstance().get("wikipedia", "test");
-//        wiktionary = ResourceFactory.getInstance().get("wiktionary", "en");
+    public static void setup()
+    {
+        oldWorkspace = System.getProperty(LSRFramework.SYS_LSR_WORKSPACE);
+        System.setProperty(LSRFramework.SYS_LSR_WORKSPACE,
+                "target/test-output/PathLengthComparatorTest/");
     }
-
+    
+    @AfterClass
+    public static void teardown()
+    {
+         System.setProperty(LSRFramework.SYS_LSR_WORKSPACE, oldWorkspace);
+    }
+    
     @Ignore("The original GermaNet API is not Apache licensed.")
     @Test
 	public void testGermaNetUsingResourceLoader()
 		throws Exception
 	{
+        LexicalSemanticResource germanet = ResourceFactory.getInstance().get("germanet7", "de");
+        
         LexSemResourceComparator comparator = new PathLengthComparator(germanet);
 
         Set<Entity> entitiesAuto    = germanet.getEntity("Auto", PoS.n);
@@ -69,13 +75,15 @@ public class PathLengthComparatorTest {
         assertEquals(6.0, comparator.getSimilarity(entitiesAuto, entitiesSchnell), epsilon);
     }
 
-//    @Ignore("The path from 'tree' to 'tree' should be 0 but is 13! - See bug 163")
     @Test
 	public void testWordNet()
 		throws Exception
 	{
         Assume.assumeTrue(Runtime.getRuntime().maxMemory() > 1000000000);
 
+        LexicalSemanticResource wordnet = ResourceFactory.getInstance().get("wordnet-default",
+                "en");
+        
 		LexSemResourceComparator comparator = new PathLengthComparator(wordnet);
 
         Set<Entity> entitiesTree  = wordnet.getEntity("tree", PoS.n);
@@ -94,6 +102,8 @@ public class PathLengthComparatorTest {
 	{
         Assume.assumeTrue(Runtime.getRuntime().maxMemory() > 1000000000);
 
+        LexicalSemanticResource wikipedia = ResourceFactory.getInstance().get("wikipedia", "test");
+        
 		LexSemResourceComparator comparator = new PathLengthComparator(wikipedia);
 
         // this are pages
@@ -132,6 +142,8 @@ public class PathLengthComparatorTest {
 	public void testWiktionary()
 		throws Exception
 	{
+        LexicalSemanticResource wiktionary = ResourceFactory.getInstance().get("wiktionary", "en");
+        
         LexSemResourceComparator comparator = new PathLengthComparator(wiktionary);
 
         Set<Entity> entitiesFahrzeug = wiktionary.getEntity("Fahrzeug");

--- a/dkpro-similarity-algorithms-lsr-asl/src/test/resources/log4j.properties
+++ b/dkpro-similarity-algorithms-lsr-asl/src/test/resources/log4j.properties
@@ -1,0 +1,7 @@
+log4j.rootLogger=WARN,development
+
+log4j.appender.development=org.apache.log4j.ConsoleAppender
+log4j.appender.development.layout=org.apache.log4j.PatternLayout
+log4j.appender.development.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %5p [%t] (%C{1}) - %m%n
+
+log4j.logger.de.tudarmstadt.ukp = DEBUG

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <module>dkpro-similarity-experiments</module>
       </modules>
       <properties>
-        <lsr.version>0.8.1</lsr.version>
+        <lsr.version>0.8.2-SNAPSHOT</lsr.version>
       </properties>
       <repositories>
         <repository>


### PR DESCRIPTION
- Upgrade to DKPro LSR 0.8.2-SNAPSHOT
- Use WordNet via Maven in the PathLengthComparatorTest